### PR TITLE
[build] Add UWVM_VERSION_BETA definition and update color coding for …

### DIFF
--- a/src/uwvm2/uwvm/cmdline/callback/version.h
+++ b/src/uwvm2/uwvm/cmdline/callback/version.h
@@ -222,20 +222,20 @@ UWVM_MODULE_EXPORT namespace uwvm2::uwvm::cmdline::params::details
                                 ::uwvm2::uwvm::custom::uwvm_version,
         // flags
 #if defined(UWVM_VERSION_DEV)
-                                ::fast_io::mnp::cond(::uwvm2::uwvm::utils::ansies::put_color, UWVM_COLOR_U8_LT_PURPLE),
+                                ::fast_io::mnp::cond(::uwvm2::uwvm::utils::ansies::put_color, UWVM_COLOR_U8_CYAN),
                                 u8" [dev]",
 #elif defined(UWVM_VERSION_ALPHA)
-                                ::fast_io::mnp::cond(::uwvm2::uwvm::utils::ansies::put_color, UWVM_COLOR_U8_LT_PURPLE),
+                                ::fast_io::mnp::cond(::uwvm2::uwvm::utils::ansies::put_color, UWVM_COLOR_U8_LT_RED),
                                 u8" [alpha]",
 #elif defined(UWVM_VERSION_BETA)
-                                ::fast_io::mnp::cond(::uwvm2::uwvm::utils::ansies::put_color, UWVM_COLOR_U8_LT_PURPLE),
+                                ::fast_io::mnp::cond(::uwvm2::uwvm::utils::ansies::put_color, UWVM_COLOR_U8_LT_GREEN),
                                 u8" [beta]",
 #elif defined(UWVM_VERSION_RELEASE_CANDIDATE)
                                 ::fast_io::mnp::cond(::uwvm2::uwvm::utils::ansies::put_color, UWVM_COLOR_U8_LT_PURPLE),
-                                u8" [rc]",
+                                u8" [candidate]",
 #elif defined(UWVM_VERSION_STABLE_RELEASE)
-                                ::fast_io::mnp::cond(::uwvm2::uwvm::utils::ansies::put_color, UWVM_COLOR_U8_LT_PURPLE),
-                                u8" [sr]",
+                                ::fast_io::mnp::cond(::uwvm2::uwvm::utils::ansies::put_color, UWVM_COLOR_U8_ORANGE),
+                                u8" [release]",
 #endif
                                 // git commit data
                                 ::fast_io::mnp::cond(::uwvm2::uwvm::utils::ansies::put_color, UWVM_COLOR_U8_RST_ALL),

--- a/xmake.lua
+++ b/xmake.lua
@@ -8,6 +8,7 @@ add_defines("UWVM_VERSION_X=2")
 add_defines("UWVM_VERSION_Y=0")
 add_defines("UWVM_VERSION_Z=1")
 add_defines("UWVM_VERSION_S=1")
+add_defines("UWVM_VERSION_BETA")
 
 set_allowedplats("windows", "mingw", "cygwin", "linux", "djgpp", "unix", "bsd", "freebsd", "dragonflybsd", "netbsd",
 	"openbsd", "macosx", "iphoneos", "watchos", "wasm-wasi", "wasm-wasip1", "wasm-wasip2", "wasm-wasip3",


### PR DESCRIPTION
…version flags

- Introduced a new definition for `UWVM_VERSION_BETA` in the build configuration to indicate beta releases.
- Updated color coding for version flags in the command line output to enhance visibility and clarity, differentiating between dev, alpha, beta, release candidate, and stable release versions.