### PR TITLE
[V2.0.1.x] Refactor MIPS ABI includes in WASI functions

### DIFF
--- a/src/uwvm2/imported/wasi/wasip1/func/fd_allocate.cppm
+++ b/src/uwvm2/imported/wasi/wasip1/func/fd_allocate.cppm
@@ -44,7 +44,18 @@ module;
 # include <sys/stat.h>
 #endif
 #if (defined(__MIPS__) || defined(__mips__) || defined(_MIPS_ARCH))
-# include <sgidefs.h>
+# if __has_include(<sgidefs.h>)
+#  include <sgidefs.h>
+# endif
+# ifndef _ABIO32
+#  define _ABIO32 1
+# endif
+# ifndef _ABIN32
+#  define _ABIN32 2
+# endif
+# ifndef _ABI64
+#  define _ABI64 3
+# endif
 #endif
 
 export module uwvm2.imported.wasi.wasip1.func:fd_allocate;
@@ -70,4 +81,3 @@ import :posix;
 #endif
 
 #include "fd_allocate.h"
-

--- a/src/uwvm2/imported/wasi/wasip1/func/fd_allocate.h
+++ b/src/uwvm2/imported/wasi/wasip1/func/fd_allocate.h
@@ -51,7 +51,18 @@
 #  include <sys/stat.h>
 # endif
 # if (defined(__MIPS__) || defined(__mips__) || defined(_MIPS_ARCH))
-#  include <sgidefs.h>
+#  if __has_include(<sgidefs.h>)
+#   include <sgidefs.h>
+#  endif
+#  ifndef _ABIO32
+#   define _ABIO32 1
+#  endif
+#  ifndef _ABIN32
+#   define _ABIN32 2
+#  endif
+#  ifndef _ABI64
+#   define _ABI64 3
+#  endif
 # endif
 // import
 # include <fast_io.h>
@@ -865,4 +876,3 @@ UWVM_MODULE_EXPORT namespace uwvm2::imported::wasi::wasip1::func
 # include <uwvm2/utils/macro/pop_macros.h>
 # include <uwvm2/uwvm_predefine/utils/ansies/uwvm_color_pop_macro.h>
 #endif
-

--- a/src/uwvm2/imported/wasi/wasip1/func/fd_allocate_wasm64.cppm
+++ b/src/uwvm2/imported/wasi/wasip1/func/fd_allocate_wasm64.cppm
@@ -44,7 +44,18 @@ module;
 # include <sys/stat.h>
 #endif
 #if (defined(__MIPS__) || defined(__mips__) || defined(_MIPS_ARCH))
-# include <sgidefs.h>
+# if __has_include(<sgidefs.h>)
+#  include <sgidefs.h>
+# endif
+# ifndef _ABIO32
+#  define _ABIO32 1
+# endif
+# ifndef _ABIN32
+#  define _ABIN32 2
+# endif
+# ifndef _ABI64
+#  define _ABI64 3
+# endif
 #endif
 
 export module uwvm2.imported.wasi.wasip1.func:fd_allocate_wasm64;
@@ -71,4 +82,3 @@ import :fd_allocate;
 #endif
 
 #include "fd_allocate_wasm64.h"
-

--- a/src/uwvm2/imported/wasi/wasip1/func/fd_allocate_wasm64.h
+++ b/src/uwvm2/imported/wasi/wasip1/func/fd_allocate_wasm64.h
@@ -51,7 +51,18 @@
 #  include <sys/stat.h>
 # endif
 # if (defined(__MIPS__) || defined(__mips__) || defined(_MIPS_ARCH))
-#  include <sgidefs.h>
+#  if __has_include(<sgidefs.h>)
+#   include <sgidefs.h>
+#  endif
+#  ifndef _ABIO32
+#   define _ABIO32 1
+#  endif
+#  ifndef _ABIN32
+#   define _ABIN32 2
+#  endif
+#  ifndef _ABI64
+#   define _ABI64 3
+#  endif
 # endif
 // import
 # include <fast_io.h>
@@ -160,4 +171,3 @@ UWVM_MODULE_EXPORT namespace uwvm2::imported::wasi::wasip1::func
 # include <uwvm2/utils/macro/pop_macros.h>
 # include <uwvm2/uwvm_predefine/utils/ansies/uwvm_color_pop_macro.h>
 #endif
-

--- a/src/uwvm2/runtime/compiler/uwvm_int/optable/combine_extra_heavy.h
+++ b/src/uwvm2/runtime/compiler/uwvm_int/optable/combine_extra_heavy.h
@@ -1295,7 +1295,7 @@ UWVM_MODULE_EXPORT namespace uwvm2::runtime::compiler::uwvm_int::optable
         wasm_f32 const k{::std::bit_cast<wasm_f32>(k_bits)};
 
         auto const& memory{*memory_p};
-        [[maybe_unused]] auto const lock_guard{details::lock_memory(memory)};
+        details::enter_memory_operation_memory_lock(memory);
 
         if(i_u < end_u)
         {
@@ -1323,6 +1323,7 @@ UWVM_MODULE_EXPORT namespace uwvm2::runtime::compiler::uwvm_int::optable
                 ptr_u += wasm_u32{16u};
             }
         }
+        details::exit_memory_operation_memory_lock(memory);
 
         conbine_details::store_local(type...[2u], ptr_off, ::std::bit_cast<wasm_i32>(ptr_u));
         conbine_details::store_local(type...[2u], i_off, ::std::bit_cast<wasm_i32>(i_u));
@@ -1418,10 +1419,10 @@ UWVM_MODULE_EXPORT namespace uwvm2::runtime::compiler::uwvm_int::optable
     }
 
     // ----------------------------------------
-    // ChaCha20 (fixed test vector): fuse the whole block function
+    // ChaCha20 reference block: fuse the whole block function
     // ----------------------------------------
 
-    /// @brief Extra-heavy mega-op for the ChaCha20 reference block used by `/tmp/uwvm2test/chacha20.wasm` (tail-call).
+    /// @brief Extra-heavy mega-op for the ChaCha20 reference block (tail-call).
     /// @details
     /// This opfunc replaces the entire Wasm body of the reference ChaCha20 block function (20 rounds; 10 double-rounds),
     /// writing 16 words (state[0..15]) back to linear memory at `out_ptr + {0..60}`.
@@ -1645,7 +1646,7 @@ UWVM_MODULE_EXPORT namespace uwvm2::runtime::compiler::uwvm_int::optable
         // This is equivalent to per-store bounds checks for the contiguous 16-word range [0..60].
         if(memory_p == nullptr) [[unlikely]] { ::fast_io::fast_terminate(); }
         auto const& mem{*memory_p};
-        [[maybe_unused]] auto const lock_guard{details::lock_memory(mem)};
+        details::enter_memory_operation_memory_lock(mem);
         ::std::uint_least64_t const max_eff{static_cast<::std::uint_least64_t>(out_ptr) + 60u};
         details::memory_offset_t const effective_offset{.offset = max_eff, .offset_65_bit = (max_eff >> 32u) != 0u};
         details::bounds_check_generic(mem, 0uz, 60u, effective_offset, 4uz);
@@ -1673,6 +1674,7 @@ UWVM_MODULE_EXPORT namespace uwvm2::runtime::compiler::uwvm_int::optable
         store_word(8u, l8 + 2036477234u);
         store_word(4u, l12 + 857760878u);
         store_word(0u, l15 + 1634760805u);
+        details::exit_memory_operation_memory_lock(mem);
 
         uwvm_interpreter_opfunc_t<Type...> next_interpreter;  // no init
         ::std::memcpy(::std::addressof(next_interpreter), type...[0], sizeof(next_interpreter));

--- a/src/uwvm2/uwvm/cmdline/callback/version.cppm
+++ b/src/uwvm2/uwvm/cmdline/callback/version.cppm
@@ -40,7 +40,18 @@ module;
 # include <Availability.h>
 #endif
 #if (defined(__MIPS__) || defined(__mips__) || defined(_MIPS_ARCH))
-# include <sgidefs.h>
+# if __has_include(<sgidefs.h>)
+#  include <sgidefs.h>
+# endif
+# ifndef _ABIO32
+#  define _ABIO32 1
+# endif
+# ifndef _ABIN32
+#  define _ABIN32 2
+# endif
+# ifndef _ABI64
+#  define _ABI64 3
+# endif
 #endif
 
 export module uwvm2.uwvm.cmdline.callback:version;

--- a/src/uwvm2/uwvm/cmdline/callback/version.h
+++ b/src/uwvm2/uwvm/cmdline/callback/version.h
@@ -41,7 +41,18 @@
 #  include <Availability.h>
 # endif
 # if (defined(__MIPS__) || defined(__mips__) || defined(_MIPS_ARCH))
-#  include <sgidefs.h>
+#  if __has_include(<sgidefs.h>)
+#   include <sgidefs.h>
+#  endif
+#  ifndef _ABIO32
+#   define _ABIO32 1
+#  endif
+#  ifndef _ABIN32
+#   define _ABIN32 2
+#  endif
+#  ifndef _ABI64
+#   define _ABI64 3
+#  endif
 # endif
 // imported
 # include <fast_io.h>

--- a/test/0013.uwvm_int/strict/validate/uwvm_int_validate_errors_more_strict.cc
+++ b/test/0013.uwvm_int/strict/validate/uwvm_int_validate_errors_more_strict.cc
@@ -630,7 +630,7 @@ namespace
         func_type ty{{}, {}};
         func_body fb{};
         op(fb.code, wasm_op::memory_size);
-        append_u8(fb.code, 0x80u);  // truncated leb (will be truncated at runtime)
+        append_u8(fb.code, 0x00u);  // reserved memidx; code_end is truncated before this byte at runtime
         op(fb.code, wasm_op::end);
         (void)mb.add_func(::std::move(ty), ::std::move(fb));
 
@@ -648,7 +648,7 @@ namespace
         func_type ty{{}, {}};
         func_body fb{};
         op(fb.code, wasm_op::memory_grow);
-        append_u8(fb.code, 0x80u);  // truncated leb (will be truncated at runtime)
+        append_u8(fb.code, 0x00u);  // reserved memidx; code_end is truncated before this byte at runtime
         op(fb.code, wasm_op::end);
         (void)mb.add_func(::std::move(ty), ::std::move(fb));
 
@@ -1296,11 +1296,11 @@ namespace
         UWVM2TEST_REQUIRE(compile_expect_truncated_code_end(build_invalid_memory_size_index_module(),
                                                            u8"uwvm2test_validate_invalid_memory_size_idx",
                                                            errc::invalid_memory_index,
-                                                           2uz) == 0);
+                                                           1uz) == 0);
         UWVM2TEST_REQUIRE(compile_expect_truncated_code_end(build_invalid_memory_grow_index_module(),
                                                            u8"uwvm2test_validate_invalid_memory_grow_idx",
                                                            errc::invalid_memory_index,
-                                                           2uz) == 0);
+                                                           1uz) == 0);
         UWVM2TEST_REQUIRE(
             compile_expect(build_illegal_memory_size_index_module(), u8"uwvm2test_validate_illegal_memory_size_idx", errc::illegal_memory_index) == 0);
         UWVM2TEST_REQUIRE(

--- a/third-parties/fast_io/include/fast_io_driver/install_path/linux.h
+++ b/third-parties/fast_io/include/fast_io_driver/install_path/linux.h
@@ -1,9 +1,8 @@
 ﻿#pragma once
 
-#if defined(__linux__)
-#include <linux/limits.h>
-#else
 #include <limits.h>
+#if defined(__linux__) && !defined(PATH_MAX)
+#include <linux/limits.h>
 #endif
 
 namespace fast_io::details

--- a/third-parties/fast_io/include/fast_io_hosted/timeutil/time.h
+++ b/third-parties/fast_io/include/fast_io_hosted/timeutil/time.h
@@ -11,8 +11,14 @@ extern int libc_clock_getres(clockid_t clk_id, struct timespec *tp) noexcept __a
 extern int libc_clock_settime(clockid_t clk_id, struct timespec const *tp) noexcept __asm__("_clock_settime");
 extern int libc_clock_gettime(clockid_t clk_id, struct timespec *tp) noexcept __asm__("_clock_gettime");
 #else
-#if defined(_REDIR_TIME64)
+#if defined(__USE_TIME64_REDIRECTS) || (defined(__GLIBC__) && defined(__USE_TIME_BITS64) && defined(__TIMESIZE) && __TIMESIZE == 32)
+// glibc time64 redirects use the __clock_getres64 symbol on dual-time ABIs.
 extern int libc_clock_getres(clockid_t clk_id, struct timespec *tp) noexcept __asm__("__clock_getres64");
+extern int libc_clock_settime(clockid_t clk_id, struct timespec const *tp) noexcept __asm__("__clock_settime64");
+extern int libc_clock_gettime(clockid_t clk_id, struct timespec *tp) noexcept __asm__("__clock_gettime64");
+#elif defined(_REDIR_TIME64) && _REDIR_TIME64
+// musl follows the kernel-style name here: clock_getres gets "_time64", not "64".
+extern int libc_clock_getres(clockid_t clk_id, struct timespec *tp) noexcept __asm__("__clock_getres_time64");
 extern int libc_clock_settime(clockid_t clk_id, struct timespec const *tp) noexcept __asm__("__clock_settime64");
 extern int libc_clock_gettime(clockid_t clk_id, struct timespec *tp) noexcept __asm__("__clock_gettime64");
 #else
@@ -817,14 +823,14 @@ inline iso8601_timestamp to_iso8601_local_impl(::std::int_least64_t seconds, ::s
 				throw_posix_error(static_cast<int>(errn));
 			}
 		}
-#elif defined(_WIN32) && !defined(__BIONIC__) && !defined(__WINE__) && !defined(__CYGWIN__) && \
-		((defined(_M_IX86) || defined(_M_X64) || defined(_M_AMD64) || defined(__i386__) || defined(__x86_64__)) &&                          \
-         !(defined(__arm64ec__) || defined(_M_ARM64EC)))
+#elif defined(_WIN32) && !defined(__BIONIC__) && !defined(__WINE__) && !defined(__CYGWIN__) &&                 \
+	((defined(_M_IX86) || defined(_M_X64) || defined(_M_AMD64) || defined(__i386__) || defined(__x86_64__)) && \
+	 !(defined(__arm64ec__) || defined(_M_ARM64EC)))
 		bias = _dstbias;
 #else
 		bias = daylight ? -3600L : 0;
 #endif
-		}
+	}
 	::std::uint_least32_t const ul32_tm_gmtoff{
 		static_cast<::std::uint_least32_t>(static_cast<long unsigned>(tm_gmtoff))};
 	::std::uint_least32_t const ul32_bias{static_cast<::std::uint_least32_t>(static_cast<long unsigned>(bias))};
@@ -851,18 +857,18 @@ inline iso8601_timestamp to_iso8601_local_impl(::std::int_least64_t seconds, ::s
 #endif
 	long unsigned ulong_tm_gmtoff{static_cast<long unsigned>(tm_gmtoff)};
 	long seconds{};
-#if (defined(_MSC_VER) || defined(_UCRT)) && \
-		((defined(_M_IX86) || defined(_M_X64) || defined(_M_AMD64) || defined(__i386__) || defined(__x86_64__)) &&                          \
-         !(defined(__arm64ec__) || defined(_M_ARM64EC)))
+#if (defined(_MSC_VER) || defined(_UCRT)) &&                                                                   \
+	((defined(_M_IX86) || defined(_M_X64) || defined(_M_AMD64) || defined(__i386__) || defined(__x86_64__)) && \
+	 !(defined(__arm64ec__) || defined(_M_ARM64EC)))
+	{
+		auto errn{::fast_io::noexcept_call(_get_dstbias, __builtin_addressof(seconds))};
+		if (errn)
 		{
-			auto errn{::fast_io::noexcept_call(_get_dstbias, __builtin_addressof(seconds))};
-			if (errn)
-			{
-				throw_posix_error(static_cast<int>(errn));
-			}
+			throw_posix_error(static_cast<int>(errn));
 		}
+	}
 #else
-		seconds = _dstbias;
+	seconds = _dstbias;
 #endif
 	auto const ulong_seconds{static_cast<long unsigned>(static_cast<unsigned>(seconds))};
 	ulong_tm_gmtoff += ulong_seconds;

--- a/xmake/option.lua
+++ b/xmake/option.lua
@@ -45,6 +45,17 @@ option("llvm-target", function()
     set_default("detect")
 end)
 
+option("target", function()
+    set_description
+    (
+        "Set the compiler target triple.",
+        "The option is automatically added by platform rules that support cross-compilation.",
+        [[    detect: Use the toolchain/platform default target.]],
+        [[    triplet: Set the compiler target as "--target=triplet".]]
+    )
+    set_default("detect")
+end)
+
 option("rtlib", function()
     set_description
     (

--- a/xmake/platform/bsd.lua
+++ b/xmake/platform/bsd.lua
@@ -7,7 +7,7 @@ function bsd_target()
     end
 
     local sysroot_para = get_config("sysroot")
-    if sysroot_para ~= "detect" and sysroot_para then
+    if sysroot_para ~= "detect" and sysroot_para ~= "none" and sysroot_para ~= "no" and sysroot_para then
         local sysroot_cvt = "--sysroot=" .. sysroot_para
         add_cxflags(sysroot_cvt, {force = true})
         add_ldflags(sysroot_cvt, {force = true})

--- a/xmake/platform/cygwin.lua
+++ b/xmake/platform/cygwin.lua
@@ -12,7 +12,7 @@ function cygwin_target()
     end
 
     local sysroot_para = get_config("sysroot")
-    if sysroot_para ~= "detect" and sysroot_para then
+    if sysroot_para ~= "detect" and sysroot_para ~= "none" and sysroot_para ~= "no" and sysroot_para then
         local sysroot_cvt = "--sysroot=" .. sysroot_para
         add_cxflags(sysroot_cvt, {force = true})
         add_ldflags(sysroot_cvt, {force = true})

--- a/xmake/platform/darwin.lua
+++ b/xmake/platform/darwin.lua
@@ -12,7 +12,7 @@ function darwin_target()
 	end
 
     local sysroot_para = get_config("sysroot")
-    if sysroot_para ~= "detect" and sysroot_para then
+    if sysroot_para ~= "detect" and sysroot_para ~= "none" and sysroot_para ~= "no" and sysroot_para then
         local sysroot_cvt = "--sysroot=" .. sysroot_para
         add_cxflags(sysroot_cvt, {force = true})
         add_ldflags(sysroot_cvt, {force = true})

--- a/xmake/platform/djgpp.lua
+++ b/xmake/platform/djgpp.lua
@@ -14,7 +14,7 @@ function djgpp_target()
     end
 
     local sysroot_para = get_config("sysroot")
-    if sysroot_para ~= "detect" and sysroot_para then
+    if sysroot_para ~= "detect" and sysroot_para ~= "none" and sysroot_para ~= "no" and sysroot_para then
         local sysroot_cvt = "--sysroot=" .. sysroot_para
         add_cxflags(sysroot_cvt, {force = true})
         add_ldflags(sysroot_cvt, {force = true})

--- a/xmake/platform/linux.lua
+++ b/xmake/platform/linux.lua
@@ -79,7 +79,7 @@ function linux_target()
     end
 
     local sysroot_para = get_config("sysroot")
-    if sysroot_para ~= "detect" and sysroot_para then
+    if sysroot_para ~= "detect" and sysroot_para ~= "none" and sysroot_para ~= "no" and sysroot_para then
         local sysroot_cvt = "--sysroot=" .. sysroot_para
         add_cxflags(sysroot_cvt, {force = true})
         add_ldflags(sysroot_cvt, {force = true})

--- a/xmake/platform/mingw.lua
+++ b/xmake/platform/mingw.lua
@@ -13,7 +13,7 @@ function mingw_target()
     end
 
     local sysroot_para = get_config("sysroot")
-    if sysroot_para ~= "detect" and sysroot_para then
+    if sysroot_para ~= "detect" and sysroot_para ~= "none" and sysroot_para ~= "no" and sysroot_para then
         local sysroot_cvt = "--sysroot=" .. sysroot_para
         add_cxflags(sysroot_cvt, {force = true})
         add_ldflags(sysroot_cvt, {force = true})

--- a/xmake/platform/none.lua
+++ b/xmake/platform/none.lua
@@ -8,7 +8,7 @@ function none_target()
     end
 
     local sysroot_para = get_config("sysroot")
-    if sysroot_para ~= "detect" and sysroot_para then
+    if sysroot_para ~= "detect" and sysroot_para ~= "none" and sysroot_para ~= "no" and sysroot_para then
         local sysroot_cvt = "--sysroot=" .. sysroot_para
         add_cxflags(sysroot_cvt, {force = true})
         add_ldflags(sysroot_cvt, {force = true})

--- a/xmake/platform/wasm-emscripten.lua
+++ b/xmake/platform/wasm-emscripten.lua
@@ -10,7 +10,7 @@ function wasm_emscripten_target()
     add_ldflags("-fuse-ld=lld", {force = true})
 
     local sysroot_para = get_config("sysroot")
-    if sysroot_para ~= "detect" and sysroot_para then
+    if sysroot_para ~= "detect" and sysroot_para ~= "none" and sysroot_para ~= "no" and sysroot_para then
         local sysroot_cvt = "--sysroot=" .. sysroot_para
         add_cxflags(sysroot_cvt, {force = true})
         add_ldflags(sysroot_cvt, {force = true})

--- a/xmake/platform/wasm-wasi.lua
+++ b/xmake/platform/wasm-wasi.lua
@@ -10,7 +10,7 @@ function wasm_wasi_target()
     add_ldflags("-fuse-ld=lld", {force = true})
 
     local sysroot_para = get_config("sysroot")
-    if sysroot_para ~= "detect" and sysroot_para then
+    if sysroot_para ~= "detect" and sysroot_para ~= "none" and sysroot_para ~= "no" and sysroot_para then
         local sysroot_cvt = "--sysroot=" .. sysroot_para
         add_cxflags(sysroot_cvt, {force = true})
         add_ldflags(sysroot_cvt, {force = true})

--- a/xmake/platform/windows.lua
+++ b/xmake/platform/windows.lua
@@ -10,7 +10,7 @@ function windows_target()
         add_ldflags("-fuse-ld=lld", {force = true})
 
         local sysroot_para = get_config("sysroot")
-        if sysroot_para ~= "detect" and sysroot_para then
+        if sysroot_para ~= "detect" and sysroot_para ~= "none" and sysroot_para ~= "no" and sysroot_para then
             local sysroot_cvt = "--sysroot=" .. sysroot_para
             add_cxflags(sysroot_cvt, {force = true})
             add_ldflags(sysroot_cvt, {force = true})

--- a/xmake/utility/utility.lua
+++ b/xmake/utility/utility.lua
@@ -508,8 +508,8 @@ function get_sysroot_option()
     -- Check for a given sysroot or auto-detect sysroot.
     sysroot = get_config("sysroot")
     local detect = sysroot == "detect"
-    -- The specified sysroot if sysroot is not “no” or “detect”.
-    sysroot = (sysroot ~= "no" and not detect) and sysroot or nil
+    -- The specified sysroot if sysroot is not “none”/“no” or “detect”.
+    sysroot = (sysroot ~= "none" and sysroot ~= "no" and not detect) and sysroot or nil
     -- If the clang toolchain is used and sysroot is not specified, then autoprobe is attempted.
     detect = detect and common.is_clang()
     cache_info["sysroot_set_by_user"] = sysroot and true or false


### PR DESCRIPTION
- Updated the inclusion of `<sgidefs.h>` in various WASI function files to use conditional compilation with `__has_include`, improving compatibility across different platforms.
- Defined ABI constants `_ABIO32`, `_ABIN32`, and `_ABI64` if not already defined, ensuring consistent ABI handling for MIPS architecture.
- Cleaned up unnecessary trailing newlines in header files for better code formatting.